### PR TITLE
fix: define token overflow dependencies

### DIFF
--- a/src/txagent/txagent.py
+++ b/src/txagent/txagent.py
@@ -3,7 +3,9 @@ import os
 import sys
 import json
 import gc
+import logging
 import numpy as np
+import torch
 from vllm import LLM, SamplingParams
 from jinja2 import Template
 from typing import List
@@ -13,6 +15,8 @@ from gradio import ChatMessage
 from .toolrag import ToolRAGModel
 
 from .utils import NoRepeatSentenceProcessor, ReasoningTraceChecker, tool_result_format
+
+logger = logging.getLogger(__name__)
 
 
 class TxAgent:


### PR DESCRIPTION
## Summary
- import torch in txagent.py for the token-overflow cleanup path
- define a module logger before logger.info() is used
- addresses the missing torch/logger runtime failure reported in issue #14

## Validation
- python -m compileall src run_example.py run_txagent_app.py
- git diff --check
