### PR TITLE
fix: correct assistant role typo

### DIFF
--- a/src/txagent/txagent.py
+++ b/src/txagent/txagent.py
@@ -359,7 +359,7 @@ class TxAgent:
             return revised_messages, existing_tools_prompt, special_tool_call
 
     def get_answer_based_on_unfinished_reasoning(self, conversation, temperature, max_new_tokens, max_token, outputs=None, return_full_thought=False):
-        if conversation[-1]['role'] == 'assisant':
+        if conversation[-1]['role'] == 'assistant':
             conversation.append(
                 {'role': 'tool', 'content': 'Errors happen during the function call, please come up with the final answer with the current information.'})
         finish_tools_prompt = self.add_finish_tools([])


### PR DESCRIPTION
## Summary
- correct the assistant role string in the unfinished-reasoning recovery path
- allow the fallback tool message branch to run for normal assistant messages

## Validation
- python -m compileall src run_example.py run_txagent_app.py
- rg "assisant" src/txagent/txagent.py
- git diff --check
