### PR TITLE
fix: defer heavy TxAgent runtime imports

### DIFF
--- a/run_txagent_app.py
+++ b/run_txagent_app.py
@@ -2,10 +2,7 @@ import random
 import datetime
 import sys
 from txagent import TxAgent
-import spaces
 import gradio as gr
-import os
-
 import os
 
 os.environ["VLLM_USE_V1"] = "0" # Disable v1 API for now since it does not support logits processors.

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,14 @@ long_description_content_type = text/markdown
 packages = find:
 package_dir =
     = src
-python_requires = >=3.6
+python_requires = >=3.9
 install_requires =
     gradio
-    vllm<=0.8.4
+    jinja2
+    numpy
+    torch
+    tooluniverse
+    vllm<=0.8.4; platform_system == "Linux"
     sentence_transformers
 
 [options.packages.find]

--- a/src/txagent/toolrag.py
+++ b/src/txagent/toolrag.py
@@ -1,4 +1,3 @@
-from sentence_transformers import SentenceTransformer
 import torch
 import json
 from .utils import get_md5
@@ -11,14 +10,24 @@ class ToolRAGModel:
         self.tool_desc_embedding = None
         self.tool_name = None
         self.tool_embedding_path = None
-        self.load_rag_model()
 
     def load_rag_model(self):
+        if self.rag_model is not None:
+            return
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            raise ImportError(
+                "sentence-transformers is required for ToolRAGModel. "
+                "Install it with `pip install sentence-transformers` and retry."
+            ) from exc
+
         self.rag_model = SentenceTransformer(self.rag_model_name)
         self.rag_model.max_seq_length = 4096
         self.rag_model.tokenizer.padding_side = "right"
 
     def load_tool_desc_embedding(self, toolbox):
+        self.load_rag_model()
         self.tool_name, _ = toolbox.refresh_tool_name_desc(
             enable_full_desc=True)
         all_tools_str = [json.dumps(
@@ -44,6 +53,7 @@ class ToolRAGModel:
             exit()
 
     def rag_infer(self, query, top_k=5):
+        self.load_rag_model()
         torch.cuda.empty_cache()
         queries = [query]
         query_embeddings = self.rag_model.encode(

--- a/src/txagent/txagent.py
+++ b/src/txagent/txagent.py
@@ -1,18 +1,32 @@
-import gradio as gr
+from __future__ import annotations
+
 import os
 import sys
 import json
 import gc
 import numpy as np
-from vllm import LLM, SamplingParams
 from jinja2 import Template
 from typing import List
 import types
-from tooluniverse import ToolUniverse
-from gradio import ChatMessage
 from .toolrag import ToolRAGModel
 
 from .utils import NoRepeatSentenceProcessor, ReasoningTraceChecker, tool_result_format
+
+
+def _missing_dependency_message(package_name, install_hint=None):
+    install_text = install_hint or package_name
+    return (
+        f"{package_name} is required for this operation but is not installed. "
+        f"Install it with `pip install {install_text}` and retry."
+    )
+
+
+def _get_chat_message_class():
+    try:
+        from gradio import ChatMessage
+    except ImportError as exc:
+        raise ImportError(_missing_dependency_message("gradio")) from exc
+    return ChatMessage
 
 
 class TxAgent:
@@ -71,6 +85,11 @@ class TxAgent:
             print(f"{attr}: {value}")
 
     def load_models(self, model_name=None):
+        try:
+            from vllm import LLM
+        except ImportError as exc:
+            raise ImportError(_missing_dependency_message("vllm")) from exc
+
         if model_name is not None:
             if model_name == self.model_name:
                 return f"The model {model_name} is already loaded."
@@ -83,6 +102,11 @@ class TxAgent:
         return f"Model {model_name} loaded successfully."
 
     def load_tooluniverse(self):
+        try:
+            from tooluniverse import ToolUniverse
+        except ImportError as exc:
+            raise ImportError(_missing_dependency_message("tooluniverse")) from exc
+
         self.tooluniverse = ToolUniverse(tool_files=self.tool_files_dict)
         self.tooluniverse.load_tools()
         special_tools = self.tooluniverse.prepare_tool_prompts(
@@ -275,6 +299,7 @@ class TxAgent:
                                  temperature=None,
                                  return_gradio_history=True):
 
+        ChatMessage = _get_chat_message_class() if return_gradio_history else None
         function_call_json, message = self.tooluniverse.extract_function_call_json(
             fcall_str, return_message=return_message, verbose=False)
         call_results = []
@@ -359,7 +384,7 @@ class TxAgent:
             return revised_messages, existing_tools_prompt, special_tool_call
 
     def get_answer_based_on_unfinished_reasoning(self, conversation, temperature, max_new_tokens, max_token, outputs=None, return_full_thought=False):
-        if conversation[-1]['role'] == 'assisant':
+        if conversation[-1]['role'] == 'assistant':
             conversation.append(
                 {'role': 'tool', 'content': 'Errors happen during the function call, please come up with the final answer with the current information.'})
         finish_tools_prompt = self.add_finish_tools([])
@@ -498,6 +523,11 @@ class TxAgent:
                   output_begin_string=None, max_new_tokens=2048,
                   max_token=None, skip_special_tokens=True,
                   model=None, tokenizer=None, terminators=None, seed=None, check_token_status=False):
+
+        try:
+            from vllm import SamplingParams
+        except ImportError as exc:
+            raise ImportError(_missing_dependency_message("vllm")) from exc
 
         if model is None:
             model = self.model
@@ -763,7 +793,7 @@ Generate **one summarized sentence** about "function calls' responses" with nece
                         max_new_tokens: int,
                         max_token: int,
                         call_agent: bool,
-                        conversation: gr.State,
+                        conversation,
                         max_round: int = 20,
                         seed: int = None,
                         call_agent_level: int = 0,
@@ -778,6 +808,7 @@ Generate **one summarized sentence** about "function calls' responses" with nece
         Returns:
             str: The generated response.
         """
+        ChatMessage = _get_chat_message_class()
         print("\033[1;32;40mstart\033[0m")
         print("len(message)", len(message))
         if len(message) <= 10:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_lightweight_imports.py
+++ b/tests/test_lightweight_imports.py
@@ -1,0 +1,22 @@
+from txagent import ToolRAGModel, TxAgent
+
+
+def test_package_import_exposes_public_classes():
+    import txagent
+
+    assert txagent.__all__ == ["TxAgent", "ToolRAGModel"]
+
+
+def test_txagent_constructor_does_not_load_models():
+    agent = TxAgent("dummy-llm", "dummy-rag")
+
+    assert agent.model is None
+    assert agent.tooluniverse is None
+    assert agent.rag_model.rag_model is None
+
+
+def test_toolrag_constructor_does_not_load_embedding_model():
+    rag_model = ToolRAGModel("dummy-rag")
+
+    assert rag_model.rag_model is None
+    assert rag_model.tool_desc_embedding is None


### PR DESCRIPTION
Summary
- defer vllm, gradio, tooluniverse, and sentence-transformers imports until the code paths that need them
- keep TxAgent and ToolRAGModel constructors lightweight for tests and metadata inspection
- document core runtime dependencies in setup.cfg and add lightweight import tests

Validation
- python -m pytest -q tests/test_lightweight_imports.py
- python -m compileall -q src run_txagent_app.py