### PR TITLE
fix: use stable cache dir for tool embeddings and remove exit() call

### DIFF
--- a/src/txagent/toolrag.py
+++ b/src/txagent/toolrag.py
@@ -1,7 +1,20 @@
 from sentence_transformers import SentenceTransformer
 import torch
+import os
+import gc
 import json
 from .utils import get_md5
+
+
+def _get_embedding_cache_dir():
+    """Return a stable cache directory for tool embeddings.
+
+    Uses ``~/.cache/txagent/embeddings`` so that the cached ``.pt`` file
+    is found regardless of the working directory at launch time.
+    """
+    cache_dir = os.path.join(os.path.expanduser("~"), ".cache", "txagent", "embeddings")
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir
 
 
 class ToolRAGModel:
@@ -25,23 +38,60 @@ class ToolRAGModel:
             each) for each in toolbox.prepare_tool_prompts(toolbox.all_tools)]
         md5_value = get_md5(str(all_tools_str))
         print("get the md value of tools:", md5_value)
-        self.tool_embedding_path = self.rag_model_name.split(
+
+        embedding_filename = self.rag_model_name.split(
             '/')[-1] + "tool_embedding_" + md5_value + ".pt"
+
+        cache_dir = _get_embedding_cache_dir()
+        self.tool_embedding_path = os.path.join(cache_dir, embedding_filename)
+
+        # Also check legacy relative-path location (backward compat)
+        legacy_path = os.path.join(os.getcwd(), embedding_filename)
+        if not os.path.exists(self.tool_embedding_path) and os.path.exists(legacy_path):
+            print(f"Migrating legacy embedding cache from {legacy_path} to {self.tool_embedding_path}")
+            os.rename(legacy_path, self.tool_embedding_path)
+
         try:
             self.tool_desc_embedding = torch.load(
                 self.tool_embedding_path, weights_only=False)
             assert len(self.tool_desc_embedding) == len(
-                toolbox.all_tools), "The number of tools in the toolbox is not equal to the number of tool_desc_embedding."
-        except:
-            self.tool_desc_embedding = None
-            print("\033[92mInferring the tool_desc_embedding.\033[0m")
-            self.tool_desc_embedding = self.rag_model.encode(
-                all_tools_str, prompt="", normalize_embeddings=True
+                toolbox.all_tools), (
+                f"The number of tools in the toolbox ({len(toolbox.all_tools)}) "
+                f"does not match the cached embeddings ({len(self.tool_desc_embedding)}). "
+                "Regenerating embeddings."
             )
-            torch.save(self.tool_desc_embedding, self.tool_embedding_path)
-            print("\033[92mFinished inferring the tool_desc_embedding.\033[0m")
-            print("\033[91mExiting. Please rerun the code to avoid the OOM issue.\033[0m")
-            exit()
+        except FileNotFoundError:
+            print(f"\033[93mEmbedding cache not found at {self.tool_embedding_path}. "
+                  "Generating tool description embeddings (this may take a few minutes).\033[0m")
+            self._generate_and_cache_embeddings(all_tools_str)
+        except AssertionError as e:
+            print(f"\033[93m{e}\033[0m")
+            print("Regenerating tool description embeddings...")
+            self._generate_and_cache_embeddings(all_tools_str)
+
+    def _generate_and_cache_embeddings(self, all_tools_str):
+        """Generate embeddings for all tool descriptions and cache to disk.
+
+        After saving, frees GPU memory used by the encoder so the main
+        model can continue without OOM.
+        """
+        self.tool_desc_embedding = self.rag_model.encode(
+            all_tools_str, prompt="", normalize_embeddings=True
+        )
+        torch.save(self.tool_desc_embedding, self.tool_embedding_path)
+        print(f"\033[92mTool embeddings saved to {self.tool_embedding_path}\033[0m")
+
+        # Free encoder GPU memory so the main LLM can continue
+        del self.rag_model
+        self.rag_model = None
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        print("\033[92mFreed RAG encoder GPU memory. Re-loading RAG model...\033[0m")
+        self.load_rag_model()
+        # Reload the cached embeddings (they may have been freed)
+        self.tool_desc_embedding = torch.load(
+            self.tool_embedding_path, weights_only=False)
 
     def rag_infer(self, query, top_k=5):
         torch.cuda.empty_cache()

--- a/tests/test_toolrag.py
+++ b/tests/test_toolrag.py
@@ -1,0 +1,230 @@
+"""Tests for the improved tool embedding cache in toolrag.py.
+
+Verifies that:
+1. Missing embedding files trigger generation (not an unhandled crash)
+2. Cached embeddings are loaded correctly
+3. Mismatched tool counts trigger regeneration
+4. Legacy relative-path embeddings are migrated
+5. GPU memory is freed after generation
+"""
+import os
+import sys
+import json
+import tempfile
+import shutil
+import hashlib
+from unittest import mock
+
+import torch
+import numpy as np
+
+# We need to import toolrag directly without going through __init__.py
+# (which imports txagent.py -> vllm which isn't available on macOS)
+# So we mock the heavy dependencies and import the module directly.
+
+# Mock sentence_transformers so we don't need the real model
+fake_st = mock.MagicMock()
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_fake_toolbox(n_tools=5):
+    """Return a mock toolbox with n_tools fake tools."""
+    toolbox = mock.MagicMock()
+    tools = [{"name": f"tool_{i}", "desc": f"description_{i}"} for i in range(n_tools)]
+    toolbox.all_tools = tools
+    toolbox.refresh_tool_name_desc.return_value = ([f"tool_{i}" for i in range(n_tools)], None)
+    toolbox.prepare_tool_prompts.return_value = tools
+    return toolbox
+
+
+def _make_fake_sentence_transformer():
+    """Return a mock SentenceTransformer that produces deterministic embeddings."""
+    model = mock.MagicMock()
+    def fake_encode(texts, prompt="", normalize_embeddings=True):
+        return np.random.randn(len(texts), 32).astype(np.float32)
+    model.encode.side_effect = fake_encode
+    def fake_similarity(a, b):
+        return torch.randn(a.shape[0], b.shape[0])
+    model.similarity.side_effect = fake_similarity
+    return model
+
+
+def _import_toolrag():
+    """Import toolrag module with sentence_transformers mocked."""
+    with mock.patch.dict('sys.modules', {'sentence_transformers': fake_st}):
+        # Clear cached module if present
+        if 'txagent.toolrag' in sys.modules:
+            del sys.modules['txagent.toolrag']
+        if 'txagent' in sys.modules:
+            del sys.modules['txagent']
+        if 'txagent.utils' in sys.modules:
+            del sys.modules['txagent.utils']
+
+        # Mock the relative import of .utils
+        utils_mock = mock.MagicMock()
+        def real_get_md5(input_str):
+            md5_hash = hashlib.md5()
+            md5_hash.update(input_str.encode('utf-8'))
+            return md5_hash.hexdigest()
+        utils_mock.get_md5 = real_get_md5
+        sys.modules['txagent'] = mock.MagicMock()
+        sys.modules['txagent.utils'] = utils_mock
+
+        # Now import from source
+        import importlib
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+        spec = importlib.util.spec_from_file_location(
+            "txagent.toolrag",
+            os.path.join(os.path.dirname(__file__), "..", "src", "txagent", "toolrag.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules['txagent.toolrag'] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+def test_missing_file_generates_embeddings():
+    """When no cached .pt file exists, embeddings should be generated and saved."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mod = _import_toolrag()
+        with mock.patch.object(mod, "_get_embedding_cache_dir", return_value=tmpdir):
+            with mock.patch.object(mod, "SentenceTransformer", return_value=_make_fake_sentence_transformer()):
+                model = mod.ToolRAGModel("mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B")
+
+                toolbox = _make_fake_toolbox(5)
+                model.load_tool_desc_embedding(toolbox)
+
+                assert model.tool_desc_embedding is not None
+                assert os.path.exists(model.tool_embedding_path)
+                assert len(model.tool_desc_embedding) == 5
+                print("PASS: test_missing_file_generates_embeddings")
+
+
+def test_cached_file_is_loaded():
+    """When a valid cached .pt file exists, it should be loaded without regeneration."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mod = _import_toolrag()
+        with mock.patch.object(mod, "_get_embedding_cache_dir", return_value=tmpdir):
+            with mock.patch.object(mod, "SentenceTransformer", return_value=_make_fake_sentence_transformer()):
+                model = mod.ToolRAGModel("mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B")
+
+                toolbox = _make_fake_toolbox(5)
+
+                # Pre-create a valid cache file
+                all_tools_str = [json.dumps(t) for t in toolbox.prepare_tool_prompts(toolbox.all_tools)]
+                md5_value = hashlib.md5(str(all_tools_str).encode()).hexdigest()
+                embedding_filename = "ToolRAG-T1-GTE-Qwen2-1.5Btool_embedding_" + md5_value + ".pt"
+                cached_path = os.path.join(tmpdir, embedding_filename)
+                fake_embeddings = np.random.randn(5, 32).astype(np.float32)
+                torch.save(fake_embeddings, cached_path)
+
+                model.load_tool_desc_embedding(toolbox)
+
+                np.testing.assert_array_equal(model.tool_desc_embedding, fake_embeddings)
+                print("PASS: test_cached_file_is_loaded")
+
+
+def test_mismatched_tool_count_regenerates():
+    """When cached embeddings have wrong count, they should be regenerated."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mod = _import_toolrag()
+        with mock.patch.object(mod, "_get_embedding_cache_dir", return_value=tmpdir):
+            with mock.patch.object(mod, "SentenceTransformer", return_value=_make_fake_sentence_transformer()):
+                model = mod.ToolRAGModel("mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B")
+
+                toolbox = _make_fake_toolbox(5)
+
+                # Pre-create cache with wrong count (3 instead of 5)
+                all_tools_str = [json.dumps(t) for t in toolbox.prepare_tool_prompts(toolbox.all_tools)]
+                md5_value = hashlib.md5(str(all_tools_str).encode()).hexdigest()
+                embedding_filename = "ToolRAG-T1-GTE-Qwen2-1.5Btool_embedding_" + md5_value + ".pt"
+                cached_path = os.path.join(tmpdir, embedding_filename)
+                wrong_embeddings = np.random.randn(3, 32).astype(np.float32)
+                torch.save(wrong_embeddings, cached_path)
+
+                model.load_tool_desc_embedding(toolbox)
+
+                assert len(model.tool_desc_embedding) == 5
+                print("PASS: test_mismatched_tool_count_regenerates")
+
+
+def test_legacy_path_migration():
+    """Legacy relative-path embeddings should be migrated to the cache dir."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = os.path.join(tmpdir, "cache")
+        os.makedirs(cache_dir)
+        cwd_dir = os.path.join(tmpdir, "cwd")
+        os.makedirs(cwd_dir)
+
+        mod = _import_toolrag()
+        with mock.patch.object(mod, "_get_embedding_cache_dir", return_value=cache_dir):
+            with mock.patch.object(mod, "SentenceTransformer", return_value=_make_fake_sentence_transformer()):
+                with mock.patch("os.getcwd", return_value=cwd_dir):
+                    model = mod.ToolRAGModel("mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B")
+
+                    toolbox = _make_fake_toolbox(5)
+
+                    all_tools_str = [json.dumps(t) for t in toolbox.prepare_tool_prompts(toolbox.all_tools)]
+                    md5_value = hashlib.md5(str(all_tools_str).encode()).hexdigest()
+                    embedding_filename = "ToolRAG-T1-GTE-Qwen2-1.5Btool_embedding_" + md5_value + ".pt"
+                    legacy_path = os.path.join(cwd_dir, embedding_filename)
+                    fake_embeddings = np.random.randn(5, 32).astype(np.float32)
+                    torch.save(fake_embeddings, legacy_path)
+
+                    model.load_tool_desc_embedding(toolbox)
+
+                    assert not os.path.exists(legacy_path), "Legacy file should be moved"
+                    assert os.path.exists(model.tool_embedding_path), "File should be in cache dir"
+                    np.testing.assert_array_equal(model.tool_desc_embedding, fake_embeddings)
+                    print("PASS: test_legacy_path_migration")
+
+
+def test_gpu_memory_freed_after_generation():
+    """After generating embeddings, the RAG model should be deleted and re-loaded."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mod = _import_toolrag()
+        with mock.patch.object(mod, "_get_embedding_cache_dir", return_value=tmpdir):
+            call_count = [0]
+            def make_model(_name=None):
+                call_count[0] += 1
+                return _make_fake_sentence_transformer()
+            with mock.patch.object(mod, "SentenceTransformer", side_effect=make_model):
+                with mock.patch("gc.collect") as mock_gc:
+                    model = mod.ToolRAGModel("mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B")
+
+                    toolbox = _make_fake_toolbox(5)
+                    initial_calls = call_count[0]
+                    model.load_tool_desc_embedding(toolbox)
+
+                    assert call_count[0] > initial_calls, "RAG model should be re-loaded after generation"
+                    assert mock_gc.called, "gc.collect should be called to free memory"
+                    print("PASS: test_gpu_memory_freed_after_generation")
+
+
+def test_no_exit_call_on_first_run():
+    """The old code called exit() after generating embeddings — the fix should NOT do that."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mod = _import_toolrag()
+        with mock.patch.object(mod, "_get_embedding_cache_dir", return_value=tmpdir):
+            with mock.patch.object(mod, "SentenceTransformer", return_value=_make_fake_sentence_transformer()):
+                model = mod.ToolRAGModel("mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B")
+                toolbox = _make_fake_toolbox(5)
+
+                # This should NOT raise SystemExit
+                model.load_tool_desc_embedding(toolbox)
+                # If we get here, exit() was not called
+                assert model.tool_desc_embedding is not None
+                print("PASS: test_no_exit_call_on_first_run")
+
+
+if __name__ == "__main__":
+    test_missing_file_generates_embeddings()
+    test_cached_file_is_loaded()
+    test_mismatched_tool_count_regenerates()
+    test_legacy_path_migration()
+    test_gpu_memory_freed_after_generation()
+    test_no_exit_call_on_first_run()
+    print("\n=== ALL TESTS PASSED ===")


### PR DESCRIPTION
## What was broken

**Issue #10:** `FileNotFoundError` when the tool embedding `.pt` cache file is not in the current working directory. The original code saved embeddings to a CWD-relative path, so users who ran TxAgent from a different directory than their first run would never find the cached file.

**Issue #6 (partial):** The `load_tool_desc_embedding` method called `exit()` after generating embeddings on first run, forcing users to restart. Combined with vLLM's `spawn` multiprocessing requirement, this created confusing `RuntimeError` messages about bootstrapping.

Additionally, the original code used a bare `except:` clause that caught ALL exceptions (including `KeyboardInterrupt` and `SystemExit`), which masked real errors and made debugging difficult.

## What the fix does

1. **Stable cache directory**: Embeddings are now saved to `~/.cache/txagent/embeddings/` instead of the current working directory, so they are found regardless of launch location.

2. **Legacy migration**: Existing CWD-relative `.pt` files are automatically moved to the new cache directory for backward compatibility.

3. **Specific exception handling**: Replaced bare `except:` with `except FileNotFoundError` and `except AssertionError` — only catches the expected failure modes.

4. **No more `exit()`**: After generating embeddings, the RAG encoder GPU memory is freed (`del` + `gc.collect` + `torch.cuda.empty_cache()`) and the encoder is re-loaded, allowing the main LLM to continue without a restart.

5. **Clear logging**: Users now see exactly what is happening — cache miss, generation progress, migration, and memory cleanup.

## Verification results

All 6 integration tests pass on macOS (no GPU required — uses mocked SentenceTransformer):

```
PASS: test_missing_file_generates_embeddings
PASS: test_cached_file_is_loaded
PASS: test_mismatched_tool_count_regenerates
PASS: test_legacy_path_migration
PASS: test_gpu_memory_freed_after_generation
PASS: test_no_exit_call_on_first_run

=== ALL TESTS PASSED ===
```

Tests verify:
- Missing file triggers generation and saves to stable cache dir
- Cached file is loaded without regeneration
- Mismatched tool count triggers regeneration with clear error message
- Legacy CWD-relative files are auto-migrated
- GPU memory is freed after generation (gc.collect called)
- No exit() call on first run (code continues normally)

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
