### PR TITLE
[codex] make ToolRAG cache configurable

### DIFF
--- a/docs/rag_reliability_checklist.md
+++ b/docs/rag_reliability_checklist.md
@@ -1,0 +1,63 @@
+# RAG Reliability Checklist
+
+Use this checklist when TxAgent returns a shallow answer, skips expected tools,
+or cites evidence that does not match the user question.
+
+## Setup
+
+- Confirm ToolUniverse loads before running the agent.
+- Confirm the ToolRAG embedding cache was generated for the current
+  ToolUniverse tool set.
+- Set `TXAGENT_TOOLRAG_CACHE_DIR` to a writable directory when the working
+  directory is read-only or shared across runs.
+- Record `init_rag_num`, `step_rag_num`, `call_agent`, model name, and vLLM
+  settings with each reproduction.
+- Re-run with the same prompt and fixed seed before changing multiple settings.
+
+## ToolRAG Cache
+
+The cache filename is derived from the RAG model name and the MD5 of the current
+ToolUniverse tool descriptions. If tools are added, removed, or their
+descriptions change, TxAgent creates a new embedding cache.
+
+```bash
+export TXAGENT_TOOLRAG_CACHE_DIR=/path/to/txagent-toolrag-cache
+```
+
+Keep the cache directory on fast local storage for repeated experiments. Delete
+only the matching `*_tool_embedding_*.pt` file when you intentionally want to
+rebuild embeddings for a changed tool set.
+
+## Query and Tool Selection
+
+- Check whether the prompt names the drug, disease, patient attribute, or
+  mechanism needed for retrieval.
+- Increase `init_rag_num` when no relevant tools appear in the initial tool
+  context.
+- Increase `step_rag_num` when the agent starts correctly but cannot retrieve
+  enough follow-up tools after intermediate observations.
+- Use `call_agent=True` when you want the agentic tool-calling loop rather than
+  a direct model response.
+
+## Evidence Grounding
+
+- Compare each final recommendation with the tool outputs returned in the same
+  run.
+- Flag recommendations that depend on facts not present in the tool outputs or
+  the user prompt.
+- Reproduce failures with a minimal prompt that preserves the drug, condition,
+  and patient-specific constraints.
+- For medication dosing questions, verify whether the relevant label,
+  contraindication, impairment, or interaction tool was available in the
+  selected tool set.
+
+## Reporting an Issue
+
+When opening an issue, include:
+
+- exact prompt
+- model names
+- `init_rag_num`, `step_rag_num`, `call_agent`, and seed
+- hardware and vLLM settings
+- selected tools or tool-call trace
+- final answer and the expected evidence source

--- a/src/txagent/__init__.py
+++ b/src/txagent/__init__.py
@@ -1,6 +1,19 @@
-from .txagent import TxAgent
-from .toolrag import ToolRAGModel
-__all__ = [
-    "TxAgent",
-    "ToolRAGModel",
-]
+"""Public package exports for TxAgent.
+
+Imports are resolved lazily so lightweight modules such as `txagent.toolrag`
+can be used without importing optional UI/runtime dependencies.
+"""
+
+__all__ = ["TxAgent", "ToolRAGModel"]
+
+
+def __getattr__(name):
+    if name == "TxAgent":
+        from .txagent import TxAgent
+
+        return TxAgent
+    if name == "ToolRAGModel":
+        from .toolrag import ToolRAGModel
+
+        return ToolRAGModel
+    raise AttributeError(f"module 'txagent' has no attribute {name!r}")

--- a/src/txagent/toolrag.py
+++ b/src/txagent/toolrag.py
@@ -1,12 +1,17 @@
 from sentence_transformers import SentenceTransformer
 import torch
 import json
+import os
+from pathlib import Path
 from .utils import get_md5
 
 
 class ToolRAGModel:
-    def __init__(self, rag_model_name):
+    def __init__(self, rag_model_name, cache_dir=None):
         self.rag_model_name = rag_model_name
+        self.cache_dir = Path(
+            cache_dir or os.environ.get("TXAGENT_TOOLRAG_CACHE_DIR", ".")
+        )
         self.rag_model = None
         self.tool_desc_embedding = None
         self.tool_name = None
@@ -25,15 +30,19 @@ class ToolRAGModel:
             each) for each in toolbox.prepare_tool_prompts(toolbox.all_tools)]
         md5_value = get_md5(str(all_tools_str))
         print("get the md value of tools:", md5_value)
-        self.tool_embedding_path = self.rag_model_name.split(
-            '/')[-1] + "tool_embedding_" + md5_value + ".pt"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        model_slug = self.rag_model_name.rstrip("/").split("/")[-1]
+        self.tool_embedding_path = str(
+            self.cache_dir / f"{model_slug}_tool_embedding_{md5_value}.pt"
+        )
         try:
             self.tool_desc_embedding = torch.load(
                 self.tool_embedding_path, weights_only=False)
             assert len(self.tool_desc_embedding) == len(
                 toolbox.all_tools), "The number of tools in the toolbox is not equal to the number of tool_desc_embedding."
-        except:
+        except Exception as exc:
             self.tool_desc_embedding = None
+            print(f"Could not load ToolRAG embedding cache: {exc}")
             print("\033[92mInferring the tool_desc_embedding.\033[0m")
             self.tool_desc_embedding = self.rag_model.encode(
                 all_tools_str, prompt="", normalize_embeddings=True

--- a/tests/test_toolrag_cache.py
+++ b/tests/test_toolrag_cache.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from txagent.toolrag import ToolRAGModel
+
+
+def test_toolrag_uses_configured_cache_dir(tmp_path):
+    with patch.object(ToolRAGModel, "load_rag_model"):
+        model = ToolRAGModel("mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B", cache_dir=tmp_path)
+
+    assert model.cache_dir == Path(tmp_path)
+    assert model.rag_model_name == "mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B"


### PR DESCRIPTION
﻿## Summary
- Add configurable ToolRAG cache directory support through `cache_dir` and `TXAGENT_TOOLRAG_CACHE_DIR`
- Make package exports lazy so `txagent.toolrag` can import without optional UI dependencies
- Add ToolRAG cache setup docs and a lightweight cache constructor test

## Validation
- `python -m py_compile src\txagent\__init__.py src\txagent\toolrag.py tests\test_toolrag_cache.py`
- `python -m pytest tests\test_toolrag_cache.py -q`
