### PR TITLE
[codex] defer TxAgent runtime imports

### DIFF
--- a/src/txagent/__init__.py
+++ b/src/txagent/__init__.py
@@ -1,6 +1,19 @@
-from .txagent import TxAgent
-from .toolrag import ToolRAGModel
-__all__ = [
-    "TxAgent",
-    "ToolRAGModel",
-]
+"""Public package exports for TxAgent.
+
+Imports are resolved lazily so lightweight modules can be used without
+importing optional UI/runtime dependencies.
+"""
+
+__all__ = ["TxAgent", "ToolRAGModel"]
+
+
+def __getattr__(name):
+    if name == "TxAgent":
+        from .txagent import TxAgent
+
+        return TxAgent
+    if name == "ToolRAGModel":
+        from .toolrag import ToolRAGModel
+
+        return ToolRAGModel
+    raise AttributeError(f"module 'txagent' has no attribute {name!r}")

--- a/tests/test_lightweight_imports.py
+++ b/tests/test_lightweight_imports.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def test_package_import_does_not_eagerly_load_runtime_dependencies():
+    import txagent
+
+    assert txagent.__all__ == ["TxAgent", "ToolRAGModel"]


### PR DESCRIPTION
## Summary
- Replace eager package exports with lazy `__getattr__` imports.
- Allow lightweight `import txagent` without importing optional UI/runtime dependencies.
- Add a lightweight import regression test.

## Validation
- `python -m pytest TxAgent\tests\test_lightweight_imports.py -q`
